### PR TITLE
Bug 752860 — correctly parse dates

### DIFF
--- a/libmsi/libmsi-summary-info.c
+++ b/libmsi/libmsi-summary-info.c
@@ -273,7 +273,7 @@ static void parse_filetime( const char *str, guint64 *ft )
 
     while ( *p == ' ' || *p == '\t' ) p++;
 
-    tm.tm_year = strtol( p, &end, 10 );
+    tm.tm_year = strtol( p, &end, 10 ) - 1900;
     if (*end != '/') return;
     p = end + 1;
 

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -221,8 +221,8 @@ Keywords: Installer
 Comments: Foobar is a registered trademark of Acme Ltd.
 Template: Intel;1033
 Revision number (UUID): {D045A303-F114-4A3B-A01D-24FC2D2A67D7}
-Created: Wed Dec 18 15:12:50 3912
-Last saved: Wed Dec 18 15:12:50 3912
+Created: Tue Dec 18 15:12:50 2012
+Last saved: Tue Dec 18 15:12:50 2012
 Version: 100 (64)
 Source: 2 (2)
 Restrict: 0 (0)


### PR DESCRIPTION
In struct tm, tm_year is the year minus 1900; this patch fixes
parse_filetime() and correct the testsuite appropriately.

This fixes #752860 and allows the tests to pass on 32-bit
platforms (previously they failed because 3912 doesn't fit in 32-bit
time_t).

Signed-off-by: Stephen Kitt <steve@sk2.org>