### PR TITLE
Only set property type once it’s safe

### DIFF
--- a/libmsi/libmsi-summary-info.c
+++ b/libmsi/libmsi-summary-info.c
@@ -353,7 +353,6 @@ static void read_properties_from_data( LibmsiOLEVariant *prop, const uint8_t *da
             break;
         }
 
-        property->vt = proptype;
         switch(proptype)
         {
         case OLEVT_I2:
@@ -409,6 +408,9 @@ static void read_properties_from_data( LibmsiOLEVariant *prop, const uint8_t *da
             g_critical("invalid type \n");
             break;
         }
+
+        /* Now we now the type is valid, store it */
+        property->vt = proptype;
     }
 }
 


### PR DESCRIPTION
Setting the property type before we know the property is valid leaves
libmsi vulnerable to invalid frees: a bad string property sets the
type, then we notice the string is invalid, and during clean-up
attempt to free an invalid pointer.

Crash discovered by Jakub Wilk, https://bugs.debian.org/869082

Signed-off-by: Stephen Kitt <steve@sk2.org>