### PR TITLE
build-sys: add missing GObject libs to LDFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,7 @@ msibuild_LDADD = -lmsi $(GLIB_LIBS) $(GSF_LIBS) $(UUID_LIBS)
 msibuild_DEPENDENCIES = libmsi/libmsi.la
 
 msiinfo_SOURCES = tools/msiinfo.c
-msiinfo_LDADD = -lmsi $(GLIB_LIBS) $(GSF_LIBS)
+msiinfo_LDADD = -lmsi $(GLIB_LIBS) $(GSF_LIBS) $(GOBJECT_LIBS)
 msiinfo_DEPENDENCIES = libmsi/libmsi.la
 
 # msiextract

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -5,9 +5,9 @@ dist_noinst_HEADERS = test.h
 noinst_PROGRAMS = testrecord testdatabase
 
 testrecord_SOURCES = testrecord.c
-testrecord_LDADD = ../libmsi/libmsi.la
+testrecord_LDADD = ../libmsi/libmsi.la $(GOBJECT_LIBS)
 testdatabase_SOURCES = testdatabase.c
-testdatabase_LDADD = ../libmsi/libmsi.la
+testdatabase_LDADD = ../libmsi/libmsi.la $(GOBJECT_LIBS)
 
 if WIN32
 noinst_PROGRAMS += testsuminfo


### PR DESCRIPTION
The project wouldn't build without these under Ubuntu 16.04.

Signed-off-by: Alberto Mardegan <mardy@users.sourceforge.net>