### PR TITLE
wxi: support Arguments attribute in shortcuts

### DIFF
--- a/tools/wixl/builder.vala
+++ b/tools/wixl/builder.vala
@@ -714,6 +714,8 @@ namespace Wixl {
                 MsiTableShortcut.set_target (rec, shortcut.Target);
             if (shortcut.Description != null)
                 MsiTableShortcut.set_description (rec, shortcut.Description);
+            if (shortcut.Arguments != null)
+                MsiTableShortcut.set_arguments (rec, shortcut.Arguments);
         }
 
         public override void visit_sequence (WixSequence sequence) throws GLib.Error {

--- a/tools/wixl/msi.vala
+++ b/tools/wixl/msi.vala
@@ -451,11 +451,11 @@ namespace Wixl {
         static construct {
             name = "Shortcut";
             sql_create = "CREATE TABLE `Shortcut` (`Shortcut` CHAR(72) NOT NULL, `Directory_` CHAR(72) NOT NULL, `Name` CHAR(128) NOT NULL LOCALIZABLE, `Component_` CHAR(72) NOT NULL, `Target` CHAR(72) NOT NULL, `Arguments` CHAR(255), `Description` CHAR(255) LOCALIZABLE, `Hotkey` INT, `Icon_` CHAR(72), `IconIndex` INT, `ShowCmd` INT, `WkDir` CHAR(72), `DisplayResourceDLL` CHAR(255), `DisplayResourceId` INT, `DescriptionResourceDLL` CHAR(255), `DescriptionResourceId` INT PRIMARY KEY `Shortcut`)";
-            sql_insert = "INSERT INTO `Shortcut` (`Shortcut`, `Directory_`, `Name`, `Component_`, `Target`, `Icon_`, `IconIndex`, `WkDir`, `Description`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            sql_insert = "INSERT INTO `Shortcut` (`Shortcut`, `Directory_`, `Name`, `Component_`, `Target`, `Icon_`, `IconIndex`, `WkDir`, `Description`, `Arguments`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         }
 
         public Libmsi.Record add (string Shortcut, string Directory, string Name, string Component) throws GLib.Error {
-            var rec = new Libmsi.Record (9);
+            var rec = new Libmsi.Record (10);
 
             if (!rec.set_string (1, Shortcut) ||
                 !rec.set_string (2, Directory) ||
@@ -490,6 +490,11 @@ namespace Wixl {
 
         public static void set_description (Libmsi.Record rec, string Description) throws GLib.Error {
             if (!rec.set_string (9, Description))
+                throw new Wixl.Error.FAILED ("failed to set record");
+        }
+
+        public static void set_arguments (Libmsi.Record rec, string Arguments) throws GLib.Error {
+            if (!rec.set_string (10, Arguments))
                 throw new Wixl.Error.FAILED ("failed to set record");
         }
     }

--- a/tools/wixl/wix.vala
+++ b/tools/wixl/wix.vala
@@ -380,6 +380,7 @@ namespace Wixl {
         public string WorkingDirectory { get; set; }
         public string Icon { get; set; }
         public string Advertise { get; set; }
+        public string Arguments { get; set; }
         public string Description { get; set; }
         public string Target { get; set; }
 


### PR DESCRIPTION
Add support for the "Arguments" attribute in shortcuts. This can be used
to specify additional parameters to the command being launched.

Signed-off-by: Alberto Mardegan <mardy@users.sourceforge.net>